### PR TITLE
sort responses by creation timestamp and show edit timestamps

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -5,14 +5,14 @@ class ResponsesController < ApplicationController
 
   def index
     @user = current_user
-    @responses = @question.responses
+    @responses = @question.responses.sort_by(&:created_at)
     @event = @question.event
   end
 
   def new
     @user = current_user
     @event = @question.event
-    @responses = @question.responses  # load existing responses
+    @responses = @question.responses.sort_by(&:created_at) # load existing responses
     @response = @question.responses.new
   end
 
@@ -32,7 +32,7 @@ class ResponsesController < ApplicationController
 
   def destroy
     authorize(@response)
-    
+
     question_id = @response.question_id
     @response.destroy
     redirect_to question_responses_path(question_id), notice: "Response was destroyed."

--- a/app/views/questions/_question.html.erb
+++ b/app/views/questions/_question.html.erb
@@ -16,12 +16,15 @@
         <span class="Ticket-reply">
           <%= link_to "#{question.user.name}", user_questions_path(question.user.id) %> asks:
         </span>
-        <span class="Ticket-timestamp"><%= time_ago_in_words(question.created_at) %> ago</span>
+        <span class="Ticket-timestamp" data-toggle="tooltip" data-placement="top" title="<%= question.created_at %>"><%= time_ago_in_words(question.created_at) %> ago</span>
       </div>
     </div>
     <div class="row u-mb-2">
       <div class="small-11 columns">
         <%= simple_format(question.copy) %>
+        <% if question.updated_at != question.created_at %>
+          <p class="small">Last edited at: <%= question.updated_at %></p>
+        <% end %>
       </div>
       <div class="small-1 columns u-textAlignCenter">
         <div class="row u-mb-2">

--- a/app/views/responses/_response.html.erb
+++ b/app/views/responses/_response.html.erb
@@ -17,10 +17,13 @@
       <span class="Ticket-reply">
         <%= link_to "#{response.user.name}", user_questions_path(response.user.id) %> responds:
       </span>
-      <span class="Ticket-timestamp"><%= time_ago_in_words(response.created_at) %> ago</span>
+      <span class="Ticket-timestamp" data-toggle="tooltip" data-placement="top" title="<%= response.created_at %>"><%= time_ago_in_words(response.created_at) %> ago</span>
     </div>
     <div class="row u-mb-3">
       <%= simple_format(response.copy) %>
+      <% if response.updated_at != response.created_at %>
+        <p class="small">Last edited at: <%= response.updated_at %></p>
+      <% end %>
     </div>
     <div class="row u-mb-2">
     <p class="small">


### PR DESCRIPTION
also allow hover over question/response relative creation timestamp to display absolute timestamp

Screenshot of timestamp changes:
![screen shot 2017-09-15 at 2 18 01 pm](https://user-images.githubusercontent.com/6101802/30497408-bc35eb38-9a20-11e7-8180-e45b4e2a382a.png)
