### PR TITLE
Require admin approval for anonymous questions to be displayed

### DIFF
--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -1,3 +1,7 @@
 // Place all the styles related to the questions controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.anonymous_unapproved {
+    background-color: #FFB5B5;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,4 +17,8 @@ class ApplicationController < ActionController::Base
   def anonymous_enabled?
     Rails.configuration.x.enable_anonymous
   end
+
+  def anonymous_requires_admin_approval?
+    Rails.configuration.x.anonymous_requires_admin_approval
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -20,10 +20,15 @@ class EventsController < ApplicationController
   def show
     @user = current_user
 
+    @questions = @event.questions
+    if anonymous_requires_admin_approval? && !@user.admin
+      @questions = @questions.where('anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)')
+    end
+
     if params[:sort] == 'date' # reverse chronological
-      @questions = @event.questions.reverse
+      @questions = @questions.reverse
     else
-      @questions = @event.questions.sort_by(&:score).reverse  # popularity by default
+      @questions = @questions.sort_by(&:score).reverse  # popularity by default
     end
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,5 +1,5 @@
 class QuestionsController < ApplicationController
-  before_action :set_question, only: [:edit, :show, :update, :destroy]
+  before_action :set_question, only: [:edit, :show, :update, :destroy, :approve, :disapprove]
   before_action :set_event, only: [:new, :create]
   before_action :set_events
 
@@ -19,7 +19,7 @@ class QuestionsController < ApplicationController
       @question = @event.questions.create(question_params.merge(event_id: @event.id, user_id: current_user.id))
     end
     authorize(@question)
-    
+
     if @question.errors.any?
       redirect_to :back, alert: "Error: " + @question.errors.full_messages.to_sentence
     else
@@ -46,6 +46,18 @@ class QuestionsController < ApplicationController
     else
       redirect_to event_path(@question.event_id, anchor: "question_#{@question.id}"), notice: 'Question was updated.'
     end
+  end
+
+  def approve
+    authorize(@question)
+    @question.update_columns(admin_approved_at: Time.now, admin_approved_by_user_id: current_user.id)
+    redirect_to event_path(@question.event_id, anchor: "question_#{@question.id}"), notice: 'Question was approved.'
+  end
+
+  def disapprove
+    authorize(@question)
+    @question.update_columns(admin_approved_at: nil, admin_approved_by_user_id: nil)
+    redirect_to event_path(@question.event_id, anchor: "question_#{@question.id}"), notice: 'Question was disapproved.'
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,11 +20,13 @@ class UsersController < ApplicationController
   end
 
   def show_questions
-    @questions = @user.questions.reverse
+    @questions = @user.questions
+    @questions = @questions.where('anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)') if anonymous_requires_admin_approval? && !current_user.admin
+    @questions = @questions.reverse
   end
 
   def show_votes
-    @questions = Question.last(10) # broken. replace with questions that the user has voted on 
+    @questions = Question.last(10) # broken. replace with questions that the user has voted on
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,8 @@ module ApplicationHelper
   def anonymous_enabled?
     Rails.configuration.x.enable_anonymous
   end
+
+  def anonymous_approval_required?
+    anonymous_enabled? && Rails.configuration.x.anonymous_requires_admin_approval
+  end
 end

--- a/app/policies/question_policy.rb
+++ b/app/policies/question_policy.rb
@@ -25,4 +25,12 @@ class QuestionPolicy < ApplicationPolicy
   def create?
     !question.event.closed?
   end
+
+  def approve?
+    user.admin?
+  end
+
+  def disapprove?
+    user.admin?
+  end
 end

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -22,7 +22,7 @@
       <div class="small-6 columns">
         <% if anonymous_enabled? %>
         <div class="checkbox">
-          <%= f.check_box :anonymous_flag, value: true, onClick: 'if(this.checked) { alert("You’ve chosen to post anonymously. Please post with the same professional courtesy and respect as you would if your name was attached to this question.") }' %>
+          <%= f.check_box :anonymous_flag, value: true, onClick: 'if(this.checked) { alert("You’ve chosen to post anonymously. This post will not be publicly visible until approved by an admin.") }' %>
           <span></span>
           <%= f.label :anonymous_flag, 'Anonymous' %>
         </div>

--- a/app/views/questions/_question.html.erb
+++ b/app/views/questions/_question.html.erb
@@ -10,7 +10,7 @@
       <%= image_tag question.user.image_url, class: 'profile-image' %>
     <% end %>
   </div>
-  <div class="small-11 columns">
+  <div class="small-11 columns <%= question.anonymous_flag && anonymous_approval_required? && !question.admin_approved_at ? 'anonymous_unapproved' : '' %>">
     <div class="row u-mb-2">
       <div class="small-12 columns">
         <span class="Ticket-reply">
@@ -25,6 +25,9 @@
         <% if question.updated_at != question.created_at %>
           <p class="small">Last edited at: <%= question.updated_at %></p>
         <% end %>
+        <% if question.admin_approved_at %>
+          <p class="small">Approved at: <%= question.admin_approved_at %></p>
+        <% end %>        
       </div>
       <div class="small-1 columns u-textAlignCenter">
         <div class="row u-mb-2">
@@ -36,7 +39,7 @@
           <% end %>
         </div>
         <div class="row u-mb-2">
-        <p></p>
+          <p></p>
         </div>
       </div>
     </div>
@@ -54,13 +57,32 @@
           <%= link_to 'Post a response', new_question_response_path(question.id) %>
         </p>
       </div>
-<% if !current_page?(url_for(:controller => 'users', :action => 'show_questions')) && !current_page?(url_for(:controller => 'users', :action => 'show_votes')) %>
+    </div>      
+    <% if !current_page?(url_for(:controller => 'users', :action => 'show_questions')) && !current_page?(url_for(:controller => 'users', :action => 'show_votes')) %>
       <% if policy(question).destroy? && current_user.admin %>
-      <div class="small-4 columns">
-      <p class="small"><%= link_to '[Admin: Destroy Question]', question_path(question.id), method: :delete, data: {:confirm => "Are you sure you want to destroy this question?"} %></p>
+    <div class="row">
+      <div class="small-8 columns">
       </div>
-      <% end %>
-      <% end %>
+      <div class="small-4 columns">
+        <p class="small"><%= link_to '[Admin: Destroy Question]', question_path(question.id), method: :delete, data: {:confirm => "Are you sure you want to destroy this question?"} %></p>
+      </div>
     </div>
+      <% end %>
+    <% end %>
+    <% if question.anonymous_flag && anonymous_approval_required? && current_user.admin %>
+    <div class="row">
+      <div class="small-6 columns">
+      </div>
+      <div class="small-6 columns">
+        <p class="small">
+        <% if question.admin_approved_at %>
+          <%= link_to '[Admin: Disapprove Anonymous Question]', disapprove_question_path(question.id), method: :put, data: {:confirm => "Are you sure you want to disapprove this question?"} %>
+        <% else %>
+          <%= link_to '[Admin: Approve Anonymous Question]', approve_question_path(question.id), method: :put, data: {:confirm => "Are you sure you want to approve this question?"} %>
+        <% end %>
+        </p>
+      </div>
+    </div>
+    <% end %>    
   </div>
 </div>

--- a/app/views/responses/_edit_form.html.erb
+++ b/app/views/responses/_edit_form.html.erb
@@ -19,7 +19,7 @@
       <div class="small-6 columns">
         <% if anonymous_enabled? %>
         <div class="checkbox">
-          <%= f.check_box :anonymous_flag, value: true, onClick: 'if(this.checked) { alert("You’ve chosen to post anonymously. Please post with the same professional courtesy and respect as you would if your name was attached to this response.") }' %>
+          <%= f.check_box :anonymous_flag, value: true, onClick: 'if(this.checked) { alert("You’ve chosen to post anonymously. This post will not be publicly visible until approved by an admin.") }' %>
           <span></span>
           <%= f.label :anonymous_flag, 'Anonymous' %>
         </div>

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -19,7 +19,7 @@
           <div class="small-6 columns">
             <% if anonymous_enabled? %>
             <div class="checkbox">
-              <%= f.check_box :anonymous_flag, value: true, onClick: 'if(this.checked) { alert("You’ve chosen to post anonymously. Please post with the same professional courtesy and respect as you would if your name was attached to this response.") }' %>
+              <%= f.check_box :anonymous_flag, value: true, onClick: 'if(this.checked) { alert("You’ve chosen to post anonymously. This post will not be publicly visible until approved by an admin.") }' %>
               <span></span>
               <%= f.label :anonymous_flag, 'Anonymous' %>
             </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module AmaModerator
     config.active_record.raise_in_transactional_callbacks = true
 
     # anonymous question and response posting
-    config.x.enable_anonymous = false
+    config.x.enable_anonymous = true
+    config.x.anonymous_requires_admin_approval = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
 
   resources :questions, only: [:destroy, :edit, :update]
   post '/questions/:id/upvote/', to: 'votes#upvote', as: 'upvote_question'
+  put '/questions/:id/approve', to: 'questions#approve', as: 'approve_question'
+  put '/questions/:id/disapprove', to: 'questions#disapprove', as: 'disapprove_question'
 
   resources :events, concerns: :has_questions
   get '/events/:id/close', to: 'events#close', as: 'close_event'

--- a/db/migrate/20180525231147_add_admin_approved_to_questions_and_responses.rb
+++ b/db/migrate/20180525231147_add_admin_approved_to_questions_and_responses.rb
@@ -1,0 +1,8 @@
+class AddAdminApprovedToQuestionsAndResponses < ActiveRecord::Migration
+  def change
+    add_column :questions, :admin_approved_by_user_id, :integer
+    add_column :questions, :admin_approved_at, :datetime
+    add_column :responses, :admin_approved_by_user_id, :integer
+    add_column :responses, :admin_approved_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151206163244) do
+ActiveRecord::Schema.define(version: 20180525231147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,8 +33,10 @@ ActiveRecord::Schema.define(version: 20151206163244) do
     t.boolean  "anonymous_flag"
     t.boolean  "closed"
     t.boolean  "deleted"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.integer  "admin_approved_by_user_id"
+    t.datetime "admin_approved_at"
   end
 
   create_table "responses", force: :cascade do |t|
@@ -43,8 +45,10 @@ ActiveRecord::Schema.define(version: 20151206163244) do
     t.string   "copy"
     t.boolean  "deleted"
     t.boolean  "anonymous_flag"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.integer  "admin_approved_by_user_id"
+    t.datetime "admin_approved_at"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Requires admin approval for anonymous questions to be displayed to non-admin users.

Example (left is admin view, right is normal user):
![screen shot 2018-05-27 at 7 19 59 pm](https://user-images.githubusercontent.com/6101802/40591706-fd3f81bc-61e3-11e8-912e-a5a7c4ab2fdb.png)


For legacy anonymous questions: backfill old anonymous questions with `admin_approved_at` = `created_at`.