### PR TITLE
Require admin approval for anonymous responses

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,3 +27,7 @@
 .Badge {
     word-break: normal;
 }
+
+.anonymous_unapproved {
+    background-color: #FFB5B5;
+}

--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -1,7 +1,3 @@
 // Place all the styles related to the questions controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
-
-.anonymous_unapproved {
-    background-color: #FFB5B5;
-}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,10 +21,10 @@ class EventsController < ApplicationController
     @user = current_user
 
     @questions = @event.questions
+    @unapproved_anonymous_questions_count = @questions.where('anonymous_flag = true AND admin_approved_at IS NULL').count
     if anonymous_requires_admin_approval? && !@user.admin
-      @questions = @questions.where('anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)')
+      @questions = @questions.approved_anonymous
     end
-
     if params[:sort] == 'date' # reverse chronological
       @questions = @questions.reverse
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
 
   def show_questions
     @questions = @user.questions
-    @questions = @questions.where('anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)') if anonymous_requires_admin_approval? && !current_user.admin
+    @questions = @questions.approved_anonymous if anonymous_requires_admin_approval? && !current_user.admin
     @questions = @questions.reverse
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,6 +7,8 @@ class Question < ActiveRecord::Base
   has_many :votes, dependent: :destroy
   has_many :responses, dependent: :destroy
 
+  scope :approved_anonymous, -> { where('anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)') }
+
   def upvotes
     votes.where('type_of LIKE ?', :up).count
   end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -4,4 +4,6 @@ class Response < ActiveRecord::Base
 
   belongs_to :user
   belongs_to :question
+
+  scope :approved_anonymous, -> { where('anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)') }
 end

--- a/app/policies/response_policy.rb
+++ b/app/policies/response_policy.rb
@@ -16,6 +16,13 @@ class ResponsePolicy < ApplicationPolicy
 
   def destroy?
   	user.id == response.user_id || user.admin?
+  end
 
+  def approve?
+    user.admin?
+  end
+
+  def disapprove?
+    user.admin?
   end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -37,6 +37,9 @@
 <div class="row u-mb-4">
   <div class="small-12 columns">
     <p class="small"><%= "#{pluralize(@event.vote_count, 'vote')} on #{pluralize(@event.questions.size, 'question')} from #{pluralize(@event.participant_count, 'person')}." %></p>
+    <% if anonymous_approval_required? %>
+    <p class="small">This event has <%= @unapproved_anonymous_questions_count %> unapproved anonymous questions.</p>
+    <% end %>
   </div>
 </div>
 <% if @event.questions.size == 0 %>

--- a/app/views/questions/_edit_form.html.erb
+++ b/app/views/questions/_edit_form.html.erb
@@ -18,7 +18,7 @@
       <div class="small-6 columns">
         <% if anonymous_enabled? %>
         <div class="checkbox">
-          <%= f.check_box :anonymous_flag, value: true, onClick: 'if(this.checked) { alert("You’ve chosen to post anonymously. Please post with the same professional courtesy and respect as you would if your name was attached to this question.") }' %>
+          <%= f.check_box :anonymous_flag, value: true, onClick: 'if(this.checked) { alert("You’ve chosen to post anonymously. This post will not be publicly visible until approved by an admin.") }' %>
           <span></span>
           <%= f.label :anonymous_flag, 'Anonymous' %>
         </div>

--- a/app/views/responses/_response.html.erb
+++ b/app/views/responses/_response.html.erb
@@ -4,38 +4,52 @@
   <% else %>
 <div class="row u-dividerTopSmall u-mb-4" id="response_<%= response.id.to_s %>">
   <% end %>
-  <div class="small-11 small-offset-1 columns">
+  <div class="small-11 small-offset-1 columns <%= response.anonymous_flag && anonymous_approval_required? && !response.admin_approved_at ? 'anonymous_unapproved' : '' %>">
     <div class="small-1 columns">
-    <% if response.anonymous_flag %>
-      <%= image_tag 'anonymous.png', class: 'profile-image' %>
-    <% else %>
-      <%= image_tag response.user.image_url, class: 'profile-image' %>
-    <% end %>
-    </div>
-  <div class="small-11 columns">
-    <div class="row u-mb-2">
-      <span class="Ticket-reply">
-        <%= link_to "#{response.user.name}", user_questions_path(response.user.id) %> responds:
-      </span>
-      <span class="Ticket-timestamp" data-toggle="tooltip" data-placement="top" title="<%= response.created_at %>"><%= time_ago_in_words(response.created_at) %> ago</span>
-    </div>
-    <div class="row u-mb-3">
-      <%= simple_format(response.copy) %>
-      <% if response.updated_at != response.created_at %>
-        <p class="small">Last edited at: <%= response.updated_at %></p>
+      <% if response.anonymous_flag %>
+        <%= image_tag 'anonymous.png', class: 'profile-image' %>
+      <% else %>
+        <%= image_tag response.user.image_url, class: 'profile-image' %>
       <% end %>
     </div>
-    <div class="row u-mb-2">
-    <p class="small">
-      <% if policy(response).edit? %>
-      <%= link_to 'Edit Response', edit_response_path(response.id) %>
+    <div class="small-11 columns">
+      <div class="row u-mb-2">
+        <span class="Ticket-reply">
+          <%= link_to "#{response.user.name}", user_questions_path(response.user.id) %> responds:
+        </span>
+        <span class="Ticket-timestamp" data-toggle="tooltip" data-placement="top" title="<%= response.created_at %>"><%= time_ago_in_words(response.created_at) %> ago</span>
+      </div>
+      <div class="row u-mb-3">
+        <%= simple_format(response.copy) %>
+        <% if response.updated_at != response.created_at %>
+          <p class="small">Last edited at: <%= response.updated_at %></p>
+        <% end %>
+        <% if response.admin_approved_at %>
+          <p class="small">Approved at: <%= response.admin_approved_at %></p>
+        <% end %>
+      </div>
+      <div class="row u-mb-2">
+        <p class="small">
+          <% if policy(response).edit? %>
+            <%= link_to 'Edit Response', edit_response_path(response.id) %>
+          <% end %>
+          <% if policy(response).destroy? && current_user.admin %>
+            <%= link_to '[Admin: Destroy Response]', response_path(response.id), method: :delete, data: { :confirm => "Are you sure you want to destroy this response?" } %>
+          <% end %>
+        </p>
+      </div>
+      <% if response.anonymous_flag && anonymous_approval_required? && current_user.admin %>
+      <div class="row u-mb-2">
+        <p class="small">
+          <% if response.admin_approved_at %>
+            <%= link_to '[Admin: Disapprove Anonymous Response]', disapprove_response_path(response.id), method: :put, data: {:confirm => "Are you sure you want to disapprove this response?" } %>
+          <% else %>
+            <%= link_to '[Admin: Approve Anonymous Response]', approve_response_path(response.id), method: :put, data: { :confirm => "Are you sure you want to approve this response?" } %>
+          <% end %>
+        </p>
+      </div>
       <% end %>
-      <% if policy(response).destroy? && current_user.admin %>
-      <%= link_to '[Admin: Destroy Response]', response_path(response.id), method: :delete, data: {:confirm => "Are you sure you want to destroy this response?"} %>
-      <% end %>
-      </p>
     </div>
-  </div>
   </div>
 </div>
 <% end %>

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -4,4 +4,7 @@
   </div>
 </div>
 <%= render @question %>
+<% if anonymous_approval_required? %>
+<p class="small">This question has <%= @unapproved_anonymous_responses_count %> unapproved anonymous responses.</p>
+<% end %>
 <%= render @responses %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get '/questions/:id/responses', to: 'responses#index', as: 'question_responses'
   post '/questions/:id/responses', to: 'responses#create'
   resources :responses, only: [:destroy, :edit, :update]
+  put '/responses/:id/approve', to: 'responses#approve', as: 'approve_response'
+  put '/responses/:id/disapprove', to: 'responses#disapprove', as: 'disapprove_response'
 
   resources :questions, only: [:destroy, :edit, :update]
   post '/questions/:id/upvote/', to: 'votes#upvote', as: 'upvote_question'


### PR DESCRIPTION
Require admin approval for anonymous responses, similar to what #20 did for anonymous questions.