### PR TITLE
always show questions where anonymous_flag is null

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,7 +7,7 @@ class Question < ActiveRecord::Base
   has_many :votes, dependent: :destroy
   has_many :responses, dependent: :destroy
 
-  scope :approved_anonymous, -> { where('anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)') }
+  scope :approved_anonymous, -> { where('anonymous_flag IS NULL OR anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)') }
 
   def upvotes
     votes.where('type_of LIKE ?', :up).count

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -5,5 +5,5 @@ class Response < ActiveRecord::Base
   belongs_to :user
   belongs_to :question
 
-  scope :approved_anonymous, -> { where('anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)') }
+  scope :approved_anonymous, -> { where('anonymous_flag IS NULL OR anonymous_flag = false OR (anonymous_flag = true AND admin_approved_at IS NOT NULL)') }
 end


### PR DESCRIPTION
Fixes a bug where all questions with `anonymous_flag = null` was not visible by non-admin users.